### PR TITLE
Fix the warning cause by missing dependency `subr-x`.

### DIFF
--- a/tree-sitter-core.el
+++ b/tree-sitter-core.el
@@ -12,6 +12,7 @@
 
 (require 'tree-sitter-dyn)
 (require 'pp)
+(require 'subr-x)
 
 (defun ts-buffer-input (byte _row _column)
   "Return current buffer's text starting from the given (0-based indexed) BYTE."


### PR DESCRIPTION
The usage of `ts-get-cli-directory` use `if-let` in `subr-x`