### PR TITLE
Integrate make to the development process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 **/*.elc
+grammars/
+tree-sitter-dyn.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,11 @@ before_install:
   - git clone -b max-26.2 https://github.com/ubolonton/evm.git $HOME/.evm
   - evm config path /tmp
   - evm install $EVM_EMACS --use --skip
-  - sudo apt-get install -y make
 addons:
   apt:
     update: true
+    packages:
+      - make
   homebrew:
     packages:
       - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,15 +40,20 @@ before_install:
   - git clone -b max-26.2 https://github.com/ubolonton/evm.git $HOME/.evm
   - evm config path /tmp
   - evm install $EVM_EMACS --use --skip
+  - sudo apt-get install -y make
+addons:
+  apt:
+    update: true
+  homebrew:
+    packages:
+      - make
+    update: true
 
 install:
-  - ./bin/build
+  - make build
 
 before_script:
   - npm install -g tree-sitter-cli
-  - ./bin/ensure-lang rust
-  - ./bin/ensure-lang javascript
-  - ./bin/ensure-lang bash
 
 script:
-  - ./bin/test
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ addons:
     packages:
       - make
   homebrew:
+    update: true
     packages:
       - make
-    update: true
 
 install:
   - make build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: help
+help: ## Prints target and a help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |  \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: build
+build: ## Build the bindings
+	@./bin/build
+	@echo "[!!] in Emacs add $(PWD) to load-path:\n\n\t(add-to-list 'load-path \"$(PWD)\")\n"
+
+.PHONY: ensure/%
+ensure/%: ## Download grammar for a given language
+	@./bin/ensure-lang $*
+	@echo "[!!] load it in Emacs: \n\n\t(require 'tree-sitter)\n\t(ts-require-language '$*)\n"
+
+.PHONY: test
+test: ensure/rust ensure/javascript ensure/bash ## Run tests
+	@./bin/test
+
+.PHONY: watch
+watch: test ## Continuous testing (requires cargo-watch)
+	@./bin/test watch

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ These types are understood only by this package. They are not recognized by `typ
     make watch
     ```
 
-On Windows, use PowerShell to run the corresponding `.ps1` scripts.
+On Windows, use PowerShell to run the corresponding `.ps1` scripts which are `./bin/build.ps1`, `./bin/ensure-lang.ps1` (this is used like this `./bin/ensure-lang.ps1 rust`) and `./bin/test.ps1`.
 
 ## Alternative
 Binding through C instead of Rust: https://github.com/karlotness/tree-sitter.el

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The author of tree-sitter articulated its merits a lot better in this [Strange L
 - Clone this repo.
 - Build:
     ```bash
-    ./bin/build
+    make build
     ```
 - Add this repo's directory to `load-path`.
 
@@ -40,7 +40,7 @@ This package is currently not bundled with any language. Parsers for individual 
 - Use the wrapper script [`bin/ensure-lang`](bin/ensure-lang) to download the grammar from [tree-sitter's GitHub org](https://github.com/tree-sitter) and build the parser:
     ```bash
     # The shared lib will be at ~/.tree-sitter/bin/rust.so (.dll on Windows)
-    ./bin/ensure-lang rust
+    make ensure/rust
     ```
 - Load it in Emacs:
     ```emacs-lisp
@@ -127,19 +127,13 @@ These types are understood only by this package. They are not recognized by `typ
     + `ts-node-to-sexp`: debug utility.
 
 ## Development
-- Make sure necessary languages are installed for tests:
-    ```bash
-    ./bin/ensure-lang rust
-    ./bin/ensure-lang javascript
-    ./bin/ensure-lang bash
-    ```
 - Testing:
     ```bash
-    ./bin/test
+    make test
     ```
 - Continuous testing (requires [cargo-watch](https://github.com/passcod/cargo-watch)):
     ```shell
-    ./bin/test watch
+    make watch
     ```
 
 On Windows, use PowerShell to run the corresponding `.ps1` scripts.


### PR DESCRIPTION
this helps with brevity of the commands one needs to type to make things happen, also, some extra
help text is provided to guide newcomers on what they are expected to do after any execution of make <thing>