### PR TITLE
Allow overwriting $EMACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ These types are understood only by this package. They are not recognized by `typ
     ```shell
     make watch
     ```
+    
+you can optionally export an environment variable called `EMACS` which will make tests to use a different binary of GNU Emacs (i.e.: `EMACS=/snap/bin/emacs make test`), otherwise the binary located with `which emacs` will be used instead.
 
 On Windows, use PowerShell to run the corresponding `.ps1` scripts which are `./bin/build.ps1`, `./bin/ensure-lang.ps1` (this is used like this `./bin/ensure-lang.ps1 rust`) and `./bin/test.ps1`.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ These types are understood only by this package. They are not recognized by `typ
     make watch
     ```
     
-you can optionally export an environment variable called `EMACS` which will make tests to use a different binary of GNU Emacs (i.e.: `EMACS=/snap/bin/emacs make test`), otherwise the binary located with `which emacs` will be used instead.
+You can optionally export an environment variable called `EMACS` which will make tests to use a different binary of GNU Emacs (i.e.: `EMACS=/snap/bin/emacs make test`), otherwise the binary located with `which emacs` is used instead.
 
 On Windows, use PowerShell to run the corresponding `.ps1` scripts which are `./bin/build.ps1`, `./bin/ensure-lang.ps1` (this is used like this `./bin/ensure-lang.ps1 rust`) and `./bin/test.ps1`.
 

--- a/bin/env.bash
+++ b/bin/env.bash
@@ -21,6 +21,4 @@ export MODULE_ORIGINAL=${MODULE_ORIGINAL:-libtree_sitter_dyn.$ext}
 export MODULE_NAME=${MODULE_NAME:-tree-sitter-dyn}
 export MODULE_RENAMED=${MODULE_NAME}.so
 export MODULE_FULL="$MODULE_DIR/$MODULE_RENAMED"
-if [ -z ${EMACS+x} ]; then ## $EMACS is not set
-    export EMACS=${EMACS:-emacs}
-fi
+export EMACS=${EMACS:-emacs}

--- a/bin/env.bash
+++ b/bin/env.bash
@@ -21,4 +21,6 @@ export MODULE_ORIGINAL=${MODULE_ORIGINAL:-libtree_sitter_dyn.$ext}
 export MODULE_NAME=${MODULE_NAME:-tree-sitter-dyn}
 export MODULE_RENAMED=${MODULE_NAME}.so
 export MODULE_FULL="$MODULE_DIR/$MODULE_RENAMED"
-export EMACS=${EMACS:-emacs}
+if [ -z ${EMACS+x} ]; then ## $EMACS is not set
+    export EMACS=${EMACS:-emacs}
+fi

--- a/bin/test
+++ b/bin/test
@@ -5,6 +5,7 @@ set -euo pipefail
 here=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 source "$here/env.bash"
 
+echo "[!!] Using Emacs binary from $(which $EMACS) version: $($EMACS --version)"
 if [[ $@ == "watch" ]]; then
     (
         cd "$PROJECT_ROOT"

--- a/tree-sitter-core.el
+++ b/tree-sitter-core.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2019  Tuấn-Anh Nguyễn
 ;;
 ;; Author: Tuấn-Anh Nguyễn <ubolonton@gmail.com>
+;;         Jorge Javier Araya Navarro <jorgejavieran@yahoo.com.mx>
 
 ;;; Commentary:
 

--- a/tree-sitter-core.el
+++ b/tree-sitter-core.el
@@ -11,10 +11,10 @@
 ;;
 ;;; Code:
 
-(if (functionp 'module-load)
-    (require 'tree-sitter-dyn nil t)
-  (error "dynamic module feature not available, please compile Emacs --with-modules option turned on"))
+(unless (functionp 'module-load)
+  (error "Dynamic module feature not available, please compile Emacs --with-modules option turned on"))
 
+(require 'tree-sitter-dyn)
 (require 'simple)
 (require 'map)
 (require 'pp)

--- a/tree-sitter-core.el
+++ b/tree-sitter-core.el
@@ -10,7 +10,9 @@
 ;;
 ;;; Code:
 
-(require 'tree-sitter-dyn)
+(if (functionp 'module-load)
+    (require 'tree-sitter-dyn t)
+  (error "dynamic module feature not available, please compile Emacs --with-modules option turned on"))
 
 (require 'simple)
 (require 'map)

--- a/tree-sitter-core.el
+++ b/tree-sitter-core.el
@@ -12,7 +12,7 @@
 ;;; Code:
 
 (if (functionp 'module-load)
-    (require 'tree-sitter-dyn t)
+    (require 'tree-sitter-dyn nil t)
   (error "dynamic module feature not available, please compile Emacs --with-modules option turned on"))
 
 (require 'simple)


### PR DESCRIPTION
Enables a developer to set the `EMACS` environment variable, allowing him to use any binary of Emacs he wants.

On my work laptop I happened to have Emacs provided by Linux Mint repos and Emacs provided by Snapcraft, the latter had dynamic modules feature turned on and was newer but tests were ran with the emacs binary that did not had dynamic modules available thus the errors.

We also add some checks when `tree-sitter-core.el` is loaded to provide a proper error message to the developer or user because the one we get from Emacs without dynamic modules is not helpful at all.

This PR solves issue #13.

# (unreleased)

  - Fix ommited argument in require. \[Jorge Javier Araya Navarro\]

  - Add me to the list of Authors for the file I have modified 😬 \[Jorge
    Javier Araya Navarro\]

  - Fail with error when (functionp 'module-load) evaluates to nil.
    \[Jorge Javier Araya Navarro\]
    
    this helps telling the user that he has no dynamic modules available
    with its Emacs installation, also helps with misleading errors in
    tests

  - Output emacs binary path and version when runnin tests. \[Jorge
    Javier Araya Navarro\]

  - Update README.md according to previous functionality addition.
    \[Jorge Javier Araya Navarro\]
    
      - reference commit cb84e30d8f51faa7d053f3faeee9e2ab47a6d009
      - fixes issue \#13

