### PR TITLE
WIP: Syntax Highlighting

### DIFF
--- a/lisp/tree-sitter-highlight.el
+++ b/lisp/tree-sitter-highlight.el
@@ -254,16 +254,14 @@ This will remove all face properties in that region."
     (with-silent-modifications
       ;; Get at least *some* node within [start, end].
       (let* ((node (ts-get-named-descendant-for-position-range (ts-root-node tree-sitter-tree) start end))
-              (matches (tree-sitter-highlight--get-matches (ts-node-start-position node) (ts-node-end-position node))))
+             (start (ts-node-start-position node))
+             (end (ts-node-end-position node))
+             (matches (tree-sitter-highlight--get-matches start end)))
         (message "highlighting %s .. %s" start end)
-        (remove-text-properties
-          (ts-node-start-position node)
-          (ts-node-end-position node)
-          '(face nil))
-        (put-text-property
-          (ts-node-start-position node)
-          (ts-node-end-position node)
-          'fontified t)
+        (remove-text-properties start end '(face nil))
+        ;; TODO: Is this the correct way to tell font-lock that we've highlighted more
+        ;; than what was requested?
+        (put-text-property start end 'fontified t)
         (seq-do #'(lambda (match)
                     (seq-do #'tree-sitter-highlight--apply (cdr match)))
           matches)))))

--- a/lisp/tree-sitter-highlight.el
+++ b/lisp/tree-sitter-highlight.el
@@ -71,7 +71,7 @@
   "Face used for label"
   :group 'tree-sitter-highlight-faces)
 
-(defface tree-sitter-operator-face '(())
+(defface tree-sitter-operator-face '((default :inherit font-lock-keyword-face))
   "Face used for operator"
   :group 'tree-sitter-highlight-faces)
 
@@ -249,7 +249,7 @@ to faces.  Each function takes no arguments."
       ;; Find changes that are within the current window
       (mapc #'(lambda (range)
                 (let ((start (aref range 0))
-                      (end (aref range 1)))
+                       (end (aref range 1)))
                   ;; TODO: Improve this
                   (tree-sitter-highlight--highlight (max wstart start) (min wend end))))
         changes))))

--- a/lisp/tree-sitter-highlight.el
+++ b/lisp/tree-sitter-highlight.el
@@ -214,7 +214,8 @@ to faces.  Each function takes no arguments."
                   (gethash (car (split-string name "\\.")) tree-sitter-highlight--face-hash)))
           (start (ts-node-start-position node))
           (end   (ts-node-end-position node)))
-    (add-face-text-property start end face)))
+    (unless (get-text-property start 'face)
+      (add-face-text-property start end face))))
 
 (defun tree-sitter-highlight--get-injection (language)
   (cond ((eq language major-mode) '(tree-sitter-highlight--query
@@ -248,7 +249,7 @@ to faces.  Each function takes no arguments."
       ;; Find changes that are within the current window
       (mapc #'(lambda (range)
                 (let ((start (aref range 0))
-                       (end (aref range 1)))
+                      (end (aref range 1)))
                   ;; TODO: Improve this
                   (tree-sitter-highlight--highlight (max wstart start) (min wend end))))
         changes))))

--- a/lisp/tree-sitter-highlight.el
+++ b/lisp/tree-sitter-highlight.el
@@ -257,7 +257,6 @@ This will remove all face properties in that region."
              (start (ts-node-start-position node))
              (end (ts-node-end-position node))
              (matches (tree-sitter-highlight--get-matches start end)))
-        (message "highlighting %s .. %s" start end)
         (remove-text-properties start end '(face nil))
         ;; TODO: Is this the correct way to tell font-lock that we've highlighted more
         ;; than what was requested?
@@ -270,7 +269,6 @@ This will remove all face properties in that region."
   "Highlight the buffer just-in-time, i.e. after the buffer was parsed with tree-sitter."
   (when old-tree
     (mapc #'(lambda (range)
-              (message "jit %s .. %s" (aref range 0) (aref range 1))
               (font-lock-flush (aref range 0) (aref range 1)))
       (ts-changed-ranges old-tree tree-sitter-tree))))
 

--- a/lisp/tree-sitter-highlight.el
+++ b/lisp/tree-sitter-highlight.el
@@ -142,7 +142,7 @@
      ("variable.parameter"    . tree-sitter-variable-parameter-face))
   "Alist of query identifier to face used for highlighting matches."
   :type '(alist :key-type string
-           :value-type face)
+                :value-type face)
   :group 'tree-sitter-highlight)
 
 (defcustom tree-sitter-highlight-query-dir nil
@@ -150,7 +150,7 @@
 Directory needs to look as follows:
 `tree-sitter-highlight-query-dir'/tree-sitter-<language>/queries/highlights.scm"
   :type '(choice (const :tag "none" nil)
-           (directory :tag "path"))
+                 (directory :tag "path"))
   :group 'tree-sitter-highlight)
 
 (defcustom tree-sitter-highlight-setup-functions nil
@@ -160,19 +160,13 @@ to faces.  Each function takes no arguments."
   :type 'hook
   :group 'tree-sitter-highlight)
 
-(defvar-local tree-sitter-highlight--capture-names nil)
 (defvar-local tree-sitter-highlight--face-hash nil
   "Hashtable from query identifier to face, built from
 `tree-sitter-highlight-default-faces' and `tree-sitter-highlight-buffer-faces'.")
 (defvar-local tree-sitter-highlight--injections nil)
 (defvar-local tree-sitter-highlight--injections-query nil)
-(defvar-local tree-sitter-highlight--jit-function nil)
-(defvar-local tree-sitter-highlight--orig-scroll-functions nil)
 (defvar-local tree-sitter-highlight--query nil)
 (defvar-local tree-sitter-highlight--query-cursor nil)
-
-(defvar-local tree-sitter-highlight--orig-buffer-function nil)
-(defvar-local tree-sitter-highlight--orig-region-function nil)
 
 (defun tree-sitter-highlight--read-file (language file)
   "Read FILE from the queries directory for the given LANGUAGE."
@@ -207,13 +201,14 @@ to faces.  Each function takes no arguments."
 (defun tree-sitter-highlight--apply (x)
   "Apply the face for the match X in the buffer."
   (let* ((node  (cdr x))
-          ;; (index (car x))
-          ;; (name  (aref tree-sitter-highlight--capture-names index))
           (name (car x))
           (face (or (gethash name tree-sitter-highlight--face-hash)
-                  (gethash (car (split-string name "\\.")) tree-sitter-highlight--face-hash)))
+                    (gethash (car (split-string name "\\.")) tree-sitter-highlight--face-hash)))
           (start (ts-node-start-position node))
           (end   (ts-node-end-position node)))
+    ;; Make sure to not override other faces that have already been placed here.
+    ;; I'm not sure if the expected behaviour is to override or not to override
+    ;; (i.e. what should take precedence in tree-sitter, the first or the last match?)
     (unless (get-text-property start 'face)
       (add-face-text-property start end face))))
 
@@ -226,6 +221,7 @@ to faces.  Each function takes no arguments."
            x)))))
 
 (defun tree-sitter-highlight--get-matches (start end)
+  "Run the query for the current buffer in the region START to END."
   (ts-set-point-range tree-sitter-highlight--query-cursor
     (ts--point-from-position start)
     (ts--point-from-position end))
@@ -234,60 +230,78 @@ to faces.  Each function takes no arguments."
     tree-sitter-highlight--query
     (ts-root-node tree-sitter-tree)
     nil
-    ;; t
     #'ts-node-text)
   )
 
-(defun tree-sitter-highlight--jit (old-tree)
-  (when old-tree
-    (let ((changes (ts-changed-ranges old-tree tree-sitter-tree))
-           (wstart (window-start))
-           (wend (window-end)))
-      ;; TODO: Remember what we've highlighted, similar to how font-lock does it.
-      ;;       Already highlighted regions shouldn't be re-highlighted.
-
-      ;; Find changes that are within the current window
-      (mapc #'(lambda (range)
-                (let ((start (aref range 0))
-                       (end (aref range 1)))
-                  ;; TODO: Improve this
-                  (tree-sitter-highlight--highlight (max wstart start) (min wend end))))
-        changes))))
-
 (defun tree-sitter-highlight--highlight (start end)
+  "Highlight the buffer from START to END with tree-sitter.
+
+This will remove all face properties in that region."
+  ;; TODO: Remember what we've highlighted, similar to how font-lock does it.
+  ;;       Already highlighted regions shouldn't be re-highlighted.
   (ts--save-context
     (with-silent-modifications
-      (remove-text-properties start
-        end
-        '(face nil))
+      (remove-text-properties start end '(face nil))
       (let ((matches (tree-sitter-highlight--get-matches start end)))
         (seq-do #'(lambda (match)
                     (seq-do #'tree-sitter-highlight--apply (cdr match)))
           matches)))))
-;; (seq-do #'tree-sitter-highlight--apply
 
-;; (ts-highlight (ts-root-node tree-sitter-tree)
-;;               tree-sitter-highlight--query-cursor
-;;               tree-sitter-highlight--query
-;;               tree-sitter-highlight--injections-query
-;;               #'ts-node-text
-;;               (lambda (start end)
-;;                 (remove-text-properties (ts-byte-to-position start)
-;;                                         (ts-byte-to-position end)
-;;                                         '(face nil)))
-;;               (lambda (language)
-;;                 (car (tree-sitter-highlight--get-injection (intern language))))
-;;               (lambda (language)
-;;                 (cadr (tree-sitter-highlight--get-injection (intern language))))
-;;               (ts-byte-from-position start)
-;;               (ts-byte-from-position end)))))
+(defun tree-sitter-highlight--jit (old-tree)
+  "Highlight the buffer just-in-time, i.e. after the buffer was parsed with tree-sitter."
+  (when old-tree
+    (let ((changes (ts-changed-ranges old-tree tree-sitter-tree))
+           (wstart (window-start))
+           (wend   (window-end)))
 
-(defun tree-sitter-highlight--highlight-window (_window start)
-  (tree-sitter-highlight--highlight start (window-end nil t)))
+      ;; The old version:
+      ;;
+      ;; Find changes that are within the current window
+      ;; (mapc #'(lambda (range)
+      ;;           (let ((start (aref range 0))
+      ;;                  (end (aref range 1)))
+      ;;             ;; TODO: Improve this
+      ;;             (tree-sitter-highlight--highlight (max wstart start) (min wend end))))
+      ;;   changes))))
+
+      ;; The new version:
+      ;; Should at least never *miss* something, but certainly does "too much" (unneeded) work.
+      ;; Checks if the start or the end of any changed range lies within window-start and window-end.
+      ;; If any does, then highlight the whole visible region.
+      (when (seq-reduce #'(lambda (acc range)
+                            (let ((start (aref range 0))
+                                  (end   (aref range 1)))
+                              (or ;; Any previous range was visible
+                                  acc
+                                  ;; ... or the start is visible
+                                  (and (>= start wstart)
+                                    (<= start wend))
+                                  ;; ... or the end is visible
+                                  (and (>= end wstart)
+                                    (<= end wend)))))
+              changes nil)
+        ;; Highlight the whole visible region.
+        (tree-sitter-highlight--highlight wstart wend)))))
+
+(defun tree-sitter-highlight--highlight-window (_window _start)
+  "Highlight the _WINDOW after scrolling took place.
+
+Sadly we currently re-highlight the whole buffer.
+The previous code (tree-sitter-highlight--highlight start (window-end nil t))
+was not correct.
+For example, if I place a single \" (without the \ ) in a Rust file and then
+scroll around, code below that \" would not be highlighted at all, if there wasn't
+anything that closed the \".
+I think this happens because we constrain the query to the visible region, and nothing matches
+there, since the start of the string is further up in the buffer, and the end of it is further down.
+"
+  (tree-sitter-highlight--highlight (point-min) (point-max)))
 
 (defun tree-sitter-highlight--enable ()
   "Enable `tree-sitter-highlight' in this buffer."
   (run-hooks  'tree-sitter-highlight-setup-functions)
+  ;; Construct the hash table for identifier (function.builtin, etc) to the face
+  ;; that should be used.
   (setq tree-sitter-highlight--face-hash
     (let ((table (make-hash-table :test 'equal)))
       (mapc (lambda (x)
@@ -295,15 +309,16 @@ to faces.  Each function takes no arguments."
                 (puthash key value table)))
         tree-sitter-highlight-default-faces)
       table))
+  ;; Read the queries for the current file type from disk.
+  ;; TODO: We could cache this for each file type I think.
   (let ((x (tree-sitter-highlight--make-queries (alist-get major-mode
                                                   tree-sitter-major-mode-language-alist))))
-    (setq tree-sitter-highlight--query (car x)
-      tree-sitter-highlight--injections-query (cadr x)))
-  (setq tree-sitter-highlight--capture-names (ts-query-capture-names tree-sitter-highlight--query))
+    (setq tree-sitter-highlight--query            (car x)
+          tree-sitter-highlight--injections-query (cadr x)))
   (setq tree-sitter-highlight--query-cursor (ts-make-query-cursor))
-  (make-variable-buffer-local 'window-scroll-functions)
-  (setq tree-sitter-highlight--orig-scroll-functions window-scroll-functions)
-  (setq window-scroll-functions (cons #'tree-sitter-highlight--highlight-window window-scroll-functions))
+  (add-hook 'window-scroll-functions
+    #'tree-sitter-highlight--highlight-window nil t)
+  ;; Highlight the current window.
   (tree-sitter-highlight--highlight-window nil (window-start))
   (add-hook 'tree-sitter-after-change-functions #'tree-sitter-highlight--jit nil t)
   )
@@ -314,7 +329,8 @@ to faces.  Each function takes no arguments."
     (remove-text-properties (point-min)
       (point-max)
       '(face nil)))
-  (setq window-scroll-functions tree-sitter-highlight--orig-scroll-functions)
+  (remove-hook 'window-scroll-functions
+    #'tree-sitter-highlight--highlight-window t)
   (remove-hook 'tree-sitter-after-change-functions #'tree-sitter-highlight--jit t))
 
 (define-minor-mode tree-sitter-highlight-mode

--- a/lisp/tree-sitter-highlight.el
+++ b/lisp/tree-sitter-highlight.el
@@ -1,0 +1,334 @@
+;;; tree-sitter-highlight.el --- Highlighting of buffers -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019  Timo von Hartz
+;;
+;; Author: Timo von Hartz <c0untlizzi@gmail.com>
+
+;;; Commentary:
+
+;; Very early implementation of highlighting.
+;;; Code:
+
+(require 'tree-sitter)
+
+(defgroup tree-sitter-highlight nil
+  "Syntax highlighting using tree-sitter."
+  :group 'tree-sitter)
+
+(defgroup tree-sitter-highlight-faces nil
+  "All the faces of tree-sitter."
+  :group 'tree-sitter-highlight)
+
+(defface tree-sitter-attribute-face '((default :inherit font-lock-preprocessor-face))
+  "Face used for attribute"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-comment-face '((default :inherit font-lock-comment-face))
+  "Face used for comment"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-constant-face '((default :inherit font-lock-constant-face))
+  "Face used for constant"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-constant-builtin-face '((default :inherit font-lock-builtin-face))
+  "Face used for constant.builtin"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-constructor-face '((default :inherit font-lock-variable-name-face))
+  "Face used for constructor"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-escape-face '(())
+  "Face used for escape"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-function-face '((default :inherit font-lock-function-name-face))
+  "Face used for function"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-function-builtin-face '((default :inherit font-lock-builtin-face))
+  "Face used for function.builtin"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-function-macro-face '((default :inherit font-lock-function-name-face))
+  "Face used for function.macro"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-function-method-face '((default :inherit font-lock-function-name-face))
+  "Face used for function.method"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-identifier-face '((default :inherit font-lock-function-name-face))
+  "Face used for identifier"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-keyword-face '((default :inherit font-lock-keyword-face))
+  "Face used for keyword"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-label-face '((default :inherit font-lock-preprocessor-face))
+  "Face used for label"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-operator-face '(())
+  "Face used for operator"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-property-face '((default :inherit font-lock-variable-name-face))
+  "Face used for property"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-punctuation-face '(())
+  "Face used for punctuation"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-punctuation-bracket-face '(())
+  "Face used for punctuation.bracket"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-punctuation-delimiter-face '(())
+  "Face used for punctuation.delimiter"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-string-face '((default :inherit font-lock-string-face))
+  "Face used for string"
+  :group 'tree-sitter-highlight-faces)
+
+(defface tree-sitter-type-face '((default :inherit font-lock-type-face))
+  "Faced used for type"
+  :group 'tree-sitter-highlight-face)
+
+(defface tree-sitter-type-builtin-face '((default :inherit font-lock-builtin-face))
+  "Face used for type.builtin"
+  :group 'tree-sitter-highlight-face)
+
+(defface tree-sitter-variable-face '((default :inherit font-lock-variable-name-face))
+  "Face used for variable"
+  :group 'tree-sitter-highlight-face)
+
+(defface tree-sitter-variable-builtin-face '((default :inherit font-lock-builtin-face))
+  "Face used for variable.builtin"
+  :group 'tree-sitter-highlight-face)
+
+(defface tree-sitter-variable-parameter-face '((default :inherit font-lock-variable-name-face))
+  "Faced used for variable.parameter"
+  :group 'tree-sitter-highlight-face)
+
+(defcustom tree-sitter-highlight-default-faces
+  '(("attribute"             . tree-sitter-attribute-face)
+     ("comment"               . tree-sitter-comment-face)
+     ("constant"              . tree-sitter-constant-face)
+     ("constant.builtin"      . tree-sitter-constant-builtin-face)
+     ("constructor"           . tree-sitter-constructor-face)
+     ("escape"                . tree-sitter-escape-face)
+     ("function"              . tree-sitter-function-face)
+     ("function.builtin"      . tree-sitter-function-builtin-face)
+     ("function.macro"        . tree-sitter-function-macro-face)
+     ("function.method"       . tree-sitter-function-method-face)
+     ("identifier"            . tree-sitter-identifier-face)
+     ("keyword"               . tree-sitter-keyword-face)
+     ("label"                 . tree-sitter-label-face)
+     ("operator"              . tree-sitter-operator-face)
+     ("property"              . tree-sitter-property-face)
+     ("punctuation"           . tree-sitter-punctuation-face)
+     ("punctuation.bracket"   . tree-sitter-punctuation-bracket-face)
+     ("punctuation.delimiter" . tree-sitter-punctuation-delimiter-face)
+     ("string"                . tree-sitter-string-face)
+     ("type"                  . tree-sitter-type-face)
+     ("type.builtin"          . tree-sitter-type-builtin-face)
+     ("variable"              . tree-sitter-variable-face)
+     ("variable.builtin"      . tree-sitter-variable-builtin-face)
+     ("variable.parameter"    . tree-sitter-variable-parameter-face))
+  "Alist of query identifier to face used for highlighting matches."
+  :type '(alist :key-type string
+           :value-type face)
+  :group 'tree-sitter-highlight)
+
+(defcustom tree-sitter-highlight-query-dir nil
+  "Where queries for languages are stored.
+Directory needs to look as follows:
+`tree-sitter-highlight-query-dir'/tree-sitter-<language>/queries/highlights.scm"
+  :type '(choice (const :tag "none" nil)
+           (directory :tag "path"))
+  :group 'tree-sitter-highlight)
+
+(defcustom tree-sitter-highlight-setup-functions nil
+  "Functions to call before initializing the highlighting system.
+These functions could alter the queries or mapping of query identifiers
+to faces.  Each function takes no arguments."
+  :type 'hook
+  :group 'tree-sitter-highlight)
+
+(defvar-local tree-sitter-highlight--capture-names nil)
+(defvar-local tree-sitter-highlight--face-hash nil
+  "Hashtable from query identifier to face, built from
+`tree-sitter-highlight-default-faces' and `tree-sitter-highlight-buffer-faces'.")
+(defvar-local tree-sitter-highlight--injections nil)
+(defvar-local tree-sitter-highlight--injections-query nil)
+(defvar-local tree-sitter-highlight--jit-function nil)
+(defvar-local tree-sitter-highlight--orig-scroll-functions nil)
+(defvar-local tree-sitter-highlight--query nil)
+(defvar-local tree-sitter-highlight--query-cursor nil)
+
+(defvar-local tree-sitter-highlight--orig-buffer-function nil)
+(defvar-local tree-sitter-highlight--orig-region-function nil)
+
+(defun tree-sitter-highlight--read-file (language file)
+  "Read FILE from the queries directory for the given LANGUAGE."
+  (let ((path (concat tree-sitter-highlight-query-dir
+                "/"
+                (format "tree-sitter-%s"
+                  (symbol-name language))
+                "/queries/"
+                file)))
+    (when (file-exists-p path)
+      (with-temp-buffer
+        (insert-file-contents path)
+        (buffer-string)))))
+
+(defun tree-sitter-highlight--make-queries (language)
+  "Parse a highlights.scm file and return a query."
+  (let* ((highlights (when tree-sitter-highlight-query-dir
+                       (if (eql language 'cpp)
+                         (concat (tree-sitter-highlight--read-file language "highlights.scm")
+                           (tree-sitter-highlight--read-file 'c "highlights.scm"))
+                         (or (tree-sitter-highlight--read-file language "highlights.scm")
+                           (error "No highlights found for %s" language)))))
+          (injections (when tree-sitter-highlight-query-dir
+                        (tree-sitter-highlight--read-file language "injections.scm")))
+          ;; (lang (tree-sitter--get-or-load-language language))
+          (lang tree-sitter-language)
+          (query (ts--make-query lang highlights))
+          ;; If we don't find any injections just ignore that.
+          (injections-query (ts--make-query lang (or injections ""))))
+    `(,query ,injections-query)))
+
+(defun tree-sitter-highlight--apply (x)
+  "Apply the face for the match X in the buffer."
+  (let* ((node  (cdr x))
+          ;; (index (car x))
+          ;; (name  (aref tree-sitter-highlight--capture-names index))
+          (name (car x))
+          (face (or (gethash name tree-sitter-highlight--face-hash)
+                  (gethash (car (split-string name "\\.")) tree-sitter-highlight--face-hash)))
+          (start (ts-node-start-position node))
+          (end   (ts-node-end-position node)))
+    (add-face-text-property start end face)))
+
+(defun tree-sitter-highlight--get-injection (language)
+  (cond ((eq language major-mode) '(tree-sitter-highlight--query
+                                     tree-sitter-highlight--injections-query))
+    (t (or (alist-get language tree-sitter-highlight--injections)
+         (let ((x (tree-sitter-highlight--make-queries language)))
+           (push '(language . x) tree-sitter-highlight--injections)
+           x)))))
+
+(defun tree-sitter-highlight--get-matches (start end)
+  (ts-set-point-range tree-sitter-highlight--query-cursor
+    (ts--point-from-position start)
+    (ts--point-from-position end))
+  (ts--query-cursor-matches
+    tree-sitter-highlight--query-cursor
+    tree-sitter-highlight--query
+    (ts-root-node tree-sitter-tree)
+    nil
+    ;; t
+    #'ts-node-text)
+  )
+
+(defun tree-sitter-highlight--jit (old-tree)
+  (when old-tree
+    (let ((changes (ts-changed-ranges old-tree tree-sitter-tree))
+           (wstart (window-start))
+           (wend (window-end)))
+      ;; TODO: Remember what we've highlighted, similar to how font-lock does it.
+      ;;       Already highlighted regions shouldn't be re-highlighted.
+
+      ;; Find changes that are within the current window
+      (mapc #'(lambda (range)
+                (let ((start (aref range 0))
+                       (end (aref range 1)))
+                  ;; TODO: Improve this
+                  (tree-sitter-highlight--highlight (max wstart start) (min wend end))))
+        changes))))
+
+(defun tree-sitter-highlight--highlight (start end)
+  (ts--save-context
+    (with-silent-modifications
+      (remove-text-properties start
+        end
+        '(face nil))
+      (let ((matches (tree-sitter-highlight--get-matches start end)))
+        (seq-do #'(lambda (match)
+                    (seq-do #'tree-sitter-highlight--apply (cdr match)))
+          matches)))))
+;; (seq-do #'tree-sitter-highlight--apply
+
+;; (ts-highlight (ts-root-node tree-sitter-tree)
+;;               tree-sitter-highlight--query-cursor
+;;               tree-sitter-highlight--query
+;;               tree-sitter-highlight--injections-query
+;;               #'ts-node-text
+;;               (lambda (start end)
+;;                 (remove-text-properties (ts-byte-to-position start)
+;;                                         (ts-byte-to-position end)
+;;                                         '(face nil)))
+;;               (lambda (language)
+;;                 (car (tree-sitter-highlight--get-injection (intern language))))
+;;               (lambda (language)
+;;                 (cadr (tree-sitter-highlight--get-injection (intern language))))
+;;               (ts-byte-from-position start)
+;;               (ts-byte-from-position end)))))
+
+(defun tree-sitter-highlight--highlight-window (_window start)
+  (tree-sitter-highlight--highlight start (window-end nil t)))
+
+(defun tree-sitter-highlight--enable ()
+  "Enable `tree-sitter-highlight' in this buffer."
+  (run-hooks  'tree-sitter-highlight-setup-functions)
+  (setq tree-sitter-highlight--face-hash
+    (let ((table (make-hash-table :test 'equal)))
+      (mapc (lambda (x)
+              (pcase-let ((`(,key . ,value) x))
+                (puthash key value table)))
+        tree-sitter-highlight-default-faces)
+      table))
+  (let ((x (tree-sitter-highlight--make-queries (alist-get major-mode
+                                                  tree-sitter-major-mode-language-alist))))
+    (setq tree-sitter-highlight--query (car x)
+      tree-sitter-highlight--injections-query (cadr x)))
+  (setq tree-sitter-highlight--capture-names (ts-query-capture-names tree-sitter-highlight--query))
+  (setq tree-sitter-highlight--query-cursor (ts-make-query-cursor))
+  (make-variable-buffer-local 'window-scroll-functions)
+  (setq tree-sitter-highlight--orig-scroll-functions window-scroll-functions)
+  (setq window-scroll-functions (cons #'tree-sitter-highlight--highlight-window window-scroll-functions))
+  (tree-sitter-highlight--highlight-window nil (window-start))
+  (add-hook 'tree-sitter-after-change-functions #'tree-sitter-highlight--jit nil t)
+  )
+
+(defun tree-sitter-highlight--disable ()
+  "Disable `tree-sitter-highlight' in this buffer."
+  (with-silent-modifications
+    (remove-text-properties (point-min)
+      (point-max)
+      '(face nil)))
+  (setq window-scroll-functions tree-sitter-highlight--orig-scroll-functions)
+  (remove-hook 'tree-sitter-after-change-functions #'tree-sitter-highlight--jit t))
+
+(define-minor-mode tree-sitter-highlight-mode
+  "Syntax highlighting with tree sitter."
+  :init-value nil
+  :lighter "tree-sitter-highlight"
+  (tree-sitter-mode)
+  (if tree-sitter-highlight-mode
+    (let ((err t))
+      (unwind-protect
+        (prog1 (tree-sitter-highlight--enable)
+          (setq err nil))
+        (when err
+          (setq tree-sitter-highlight-mode nil))))
+    (tree-sitter-highlight--disable)))
+
+(provide 'tree-sitter-highlight)
+;;; tree-sitter-highlight.el ends here

--- a/lisp/tree-sitter-highlight.el
+++ b/lisp/tree-sitter-highlight.el
@@ -97,23 +97,23 @@
 
 (defface tree-sitter-type-face '((default :inherit font-lock-type-face))
   "Faced used for type"
-  :group 'tree-sitter-highlight-face)
+  :group 'tree-sitter-highlight-faces)
 
 (defface tree-sitter-type-builtin-face '((default :inherit font-lock-builtin-face))
   "Face used for type.builtin"
-  :group 'tree-sitter-highlight-face)
+  :group 'tree-sitter-highlight-faces)
 
 (defface tree-sitter-variable-face '((default :inherit font-lock-variable-name-face))
   "Face used for variable"
-  :group 'tree-sitter-highlight-face)
+  :group 'tree-sitter-highlight-faces)
 
 (defface tree-sitter-variable-builtin-face '((default :inherit font-lock-builtin-face))
   "Face used for variable.builtin"
-  :group 'tree-sitter-highlight-face)
+  :group 'tree-sitter-highlight-faces)
 
 (defface tree-sitter-variable-parameter-face '((default :inherit font-lock-variable-name-face))
   "Faced used for variable.parameter"
-  :group 'tree-sitter-highlight-face)
+  :group 'tree-sitter-highlight-faces)
 
 (defcustom tree-sitter-highlight-default-faces
   '(("attribute"             . tree-sitter-attribute-face)


### PR DESCRIPTION
I've implemented a basic version of syntax highlighting and am looking for feedback (whether the overall approach is good).

Highlighting with tree sitter:
![tree_sitter](https://user-images.githubusercontent.com/6771282/70848034-1bcde100-1e6c-11ea-9ba2-d1114f5f8f53.png)

Highlighting with font lock:
![font_lock](https://user-images.githubusercontent.com/6771282/70848035-1ff9fe80-1e6c-11ea-956a-ebe9bb34a0bb.png)

Currently I'm not really taking advantage of the more context sensitive tree sitter information, and am just using the default font lock faces.

I'm not sure how to best distribute this `highlights.scm` file, currently users need to specify the path to `this_repo/grammars`, from which the `highlights.scm` file for the given language is then read.

~The only major bug I've noticed, is that while typing, sometimes code isn't immediatetly highlighted. For example, when I type~
```rust
union X {
    a: i32,
    b: i32;
}
// or
fn foo() {
    let z = 1337;
}
```
~Manually calling `tree-sitter-highlight--highlight` fixes that however, so I'm thinking it might have something to do with the comment on the `after-change` function in `tree-sitter.el`. My `tree-sitter-highlight--handle-change` isn't being called for unions or lets inside functions, but if I type the same let on the top level it is, I'm not quite sure what's causing that as I'm not familiar with tree sitter.~
Edit: I've fixed this, `changed_ranges` had a bug. Even if this PR isn't merged, that one commit (6bed1e1) should definetly be merged.

My current config for using this looks like this:
```emacs-lisp
(use-package f)

(add-to-list 'load-path "/vm/dev/github.com/th0rex/emacs-tree-sitter/lisp")

(require 'tree-sitter)
(seq-do #'ts-require-language '(c cpp go python rust))

;; Path to <this_repo>/grammars
(setq tree-sitter-highlight-query-dir "/vm/dev/github.com/th0rex/emacs-tree-sitter/grammars")
(require 'tree-sitter-highlight)

(defun enable-ts-hl ()
  (font-lock-mode -1) ;; Disable font-lock mode
  (tree-sitter-highlight-mode))

(add-hook 'c-mode-common-hook #'enable-ts-hl)
(add-hook 'python-mode-hook #'enable-ts-hl)
(add-hook 'rust-mode-hook #'enable-ts-hl)
```