### PR TITLE
Add lisp directory into the instructions for load-path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Prints target and a help message
 .PHONY: build
 build: ## Build the bindings
 	@./bin/build
-	@echo "[!!] in Emacs add $(PWD) to load-path:\n\n\t(add-to-list 'load-path \"$(PWD)/lisp\")\n"
+	@echo "[!!] in Emacs add $(PWD) to load-path:\n\n\t(add-to-list 'load-path \"$(PWD)/lisp\")\n\n\t(add-to-list 'load-path \"$(PWD)/langs\")"
 
 .PHONY: ensure/%
 ensure/%: ## Download grammar for a given language

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Prints target and a help message
 .PHONY: build
 build: ## Build the bindings
 	@./bin/build
-	@echo "[!!] in Emacs add $(PWD) to load-path:\n\n\t(add-to-list 'load-path \"$(PWD)\")\n"
+	@echo "[!!] in Emacs add $(PWD) to load-path:\n\n\t(add-to-list 'load-path \"$(PWD)/lisp\")\n"
 
 .PHONY: ensure/%
 ensure/%: ## Download grammar for a given language


### PR DESCRIPTION
when `make build` is ran instructions are printed on the user's terminal on how to proceed with the results of the compilation, given that the lisp files where moved into their own directory, this fix corrects the path of the Emacs Lisp files.

fixes #29 