### PR TITLE
Better and smart indentation for major modes

### DIFF
--- a/lisp/tree-sitter-indentation.el
+++ b/lisp/tree-sitter-indentation.el
@@ -1,5 +1,8 @@
 ;;; tree-sitter-indentation.el --- Better and smart indentation for major modes
 
+;; Copyright (C) 2020  Tuấn-Anh Nguyễn
+;; 
+;; Author: Jorge Javier Araya Navarro <jorge@esavara.cr>
 ;; Version: 0.5.0
 ;; Homepage: https://github.com/ubolonton/emacs-tree-sitter
 ;; Package-Requires: ((emacs "25.1"))

--- a/lisp/tree-sitter-indentation.el
+++ b/lisp/tree-sitter-indentation.el
@@ -1,0 +1,21 @@
+;;; tree-sitter-indentation.el --- Better and smart indentation for major modes
+
+;; Version: 0.5.0
+;; Homepage: https://github.com/ubolonton/emacs-tree-sitter
+;; Package-Requires: ((emacs "25.1"))
+
+;;; Commentary:
+
+;; better and smart indentation for major modes
+
+;;; Code:
+
+(require 'tree-sitter)
+
+(defgroup tree-sitter-indentation nil
+  "indentation for major modes with tree-sitter."
+  :group 'tree-sitter)
+
+
+(provide 'tree-sitter-indentation)
+;;; tree-sitter-indentation.el ends here

--- a/lisp/tree-sitter-query.el
+++ b/lisp/tree-sitter-query.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2020  Tuấn-Anh Nguyễn
 ;;
-;; Author: Jorge Javier Araya Navarro <jorgejavieran@yahoo.com.mx>
+;; Author: Jorge Javier Araya Navarro <jorge@esavara.cr>
 
 ;;; Commentary:
 


### PR DESCRIPTION
The indentation is for tree-sitter to "take the wheel" and manage indentation in files for any major mode without disregarding any possible user customization (like values set by the user in `js-indent-level` for instance) and provide a way for user and/or package maintainers to enable indentation between a language supported by tree-sitter and their preferred and unsupported major mode.

thread about this feature in emacs-devel: https://lists.gnu.org/archive/html/emacs-devel/2020-03/msg00871.html