### PR TITLE
Version tree-sitter and tree-sitter-dyn separately

### DIFF
--- a/.azure-pipelines/steps/-github-release.yml
+++ b/.azure-pipelines/steps/-github-release.yml
@@ -7,6 +7,7 @@ steps:
   inputs:
     gitHubConnection: ${{ parameters.endpoint }}
     repositoryName: ubolonton/emacs-tree-sitter
+    isDraft: true
     assetUploadMode: replace
     assets: |
       $(System.DefaultWorkingDirectory)/dist/*.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "emacs-tree-sitter"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "emacs 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emacs-tree-sitter"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Tuấn-Anh Nguyễn <ubolonton@gmail.com>"]
 edition = "2018"
 publish = false

--- a/bin/build
+++ b/bin/build
@@ -20,6 +20,7 @@ source "$here/env.bash"
 
     MODULE_DIR="$PROJECT_ROOT/target/$TARGET"
     cp -f "$MODULE_DIR/$MODULE_ORIGINAL" "./lisp/$MODULE_RENAMED"
+    echo 'LOCAL' > lisp/DYN-VERSION
 
     cask build
 )

--- a/bin/build
+++ b/bin/build
@@ -20,7 +20,7 @@ source "$here/env.bash"
 
     MODULE_DIR="$PROJECT_ROOT/target/$TARGET"
     cp -f "$MODULE_DIR/$MODULE_ORIGINAL" "./lisp/$MODULE_RENAMED"
-    echo 'LOCAL' > lisp/DYN-VERSION
+    cargo pkgid | cut -d# -f2 | cut -d: -f2 | tr -d $'\n' > lisp/DYN-VERSION
 
     cask build
 )

--- a/bin/build.ps1
+++ b/bin/build.ps1
@@ -16,10 +16,10 @@ $module_dir = "$project_root\target\$target"
 Push-Location $project_root
 
 cargo build --all $extra
-
 Copy-Item $module_dir\$module_name.dll $project_root\lisp\$module_renamed.dll
 
-Set-Content -Path "$project_root\lisp\DYN-VERSION" -Value "LOCAL" -Force
+$version = ((cargo pkgid) | Out-String).Trim().Split('#')[-1].Split(':')[-1]
+Set-Content -Path "$project_root\lisp\DYN-VERSION" -Value $version -NoNewLine -Force
 
 cask build
 

--- a/bin/build.ps1
+++ b/bin/build.ps1
@@ -19,6 +19,8 @@ cargo build --all $extra
 
 Copy-Item $module_dir\$module_name.dll $project_root\lisp\$module_renamed.dll
 
+Set-Content -Path "$project_root\lisp\DYN-VERSION" -Value "LOCAL" -Force
+
 cask build
 
 Pop-Location

--- a/lisp/tree-sitter-core.el
+++ b/lisp/tree-sitter-core.el
@@ -16,8 +16,10 @@
 
 ;; Load the dynamic module at compile time as well, to satisfy the byte compiler.
 (eval-and-compile
+  (defconst tree-sitter--dyn-version "0.8.0"
+    "Required version of the dynamic module `tree-sitter-dyn'.")
   (require 'tree-sitter-dyn-get)
-  (tree-sitter-dyn-get-ensure))
+  (tree-sitter-dyn-get-ensure tree-sitter--dyn-version))
 
 (require 'tree-sitter-dyn)
 

--- a/lisp/tree-sitter-dyn-get.el
+++ b/lisp/tree-sitter-dyn-get.el
@@ -62,10 +62,11 @@ If it's not found, try to download it."
                                 (insert-file-contents
                                  tree-sitter-dyn-get--version-file)
                                 (buffer-string))))))
-    ;; TODO: What if the module was compiled locally?
-    (when (or (not current-version)
-              (version< current-version version))
-      (tree-sitter-dyn-get--download version)))
+    ;; TODO: Write the correct version as part of the build process.
+    (unless (string= current-version "LOCAL")
+      (when (or (not current-version)
+                (version< current-version version))
+        (tree-sitter-dyn-get--download version))))
 
   ;; TODO: If the currently loaded version of `tree-sitter-dyn' is too old,
   ;; restart Emacs (or ask user to do so).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod query;
 emacs::plugin_is_GPL_compatible! {}
 
 #[emacs::module(mod_in_name = false, defun_prefix = "ts")]
-fn init(_: &Env) -> Result<()> {
+fn init(env: &Env) -> Result<()> {
+    env.call("set", (env.intern("tree-sitter-dyn--version")?, option_env!("CARGO_PKG_VERSION")))?;
     Ok(())
 }


### PR DESCRIPTION
This will make it easier to publish through *build-from-Lisp-source* methods, like MELPA and straight.el.