### PR TITLE
langs: register tuareg-mode as a major mode for ocaml

### DIFF
--- a/langs/tree-sitter-langs.el
+++ b/langs/tree-sitter-langs.el
@@ -101,6 +101,7 @@ See `tree-sitter-langs-repos'."
                 (rustic-mode     . rust)
                 (scala-mode      . scala)
                 (swift-mode      . swift)
+                (tuareg-mode     . ocaml)
                 (typescript-mode . typescript))))
   (setf (map-elt tree-sitter-major-mode-language-alist major-mode)
         lang-symbol))


### PR DESCRIPTION
Add `tuareg-mode` (https://github.com/ocaml/tuareg) to `tree-sitter-major-mode-language-alist` as a major mode for editing ocaml.