### PR TITLE
Add Elm and C# to emacs-tree-sitter

### DIFF
--- a/langs/tree-sitter-langs-build.el
+++ b/langs/tree-sitter-langs-build.el
@@ -85,7 +85,7 @@ If VERSION and OS are not specified, use the defaults of
     (c-sharp    "075a1b2")
     (cpp        "5e7476b")
     (css        "23f2cb9")
-    (elm        nil nil "https://github.com/razzeee/tree-sitter-elm")
+    (elm        "cbec3e4" nil "https://github.com/razzeee/tree-sitter-elm")
     (fluent     "858fdd6")
     (go         "f5cae4e")
     (html       "92c17db")

--- a/langs/tree-sitter-langs-build.el
+++ b/langs/tree-sitter-langs-build.el
@@ -85,7 +85,7 @@ If VERSION and OS are not specified, use the defaults of
     (c-sharp    "075a1b2")
     (cpp        "5e7476b")
     (css        "23f2cb9")
-    (elm        "cbec3e4" nil "https://github.com/razzeee/tree-sitter-elm")
+    (elm        "06a8ff7" nil "https://github.com/razzeee/tree-sitter-elm")
     (fluent     "858fdd6")
     (go         "f5cae4e")
     (html       "92c17db")

--- a/langs/tree-sitter-langs-build.el
+++ b/langs/tree-sitter-langs-build.el
@@ -85,6 +85,7 @@ If VERSION and OS are not specified, use the defaults of
     (c-sharp    "075a1b2")
     (cpp        "5e7476b")
     (css        "23f2cb9")
+    (elm        nil nil "https://github.com/razzeee/tree-sitter-elm")
     (fluent     "858fdd6")
     (go         "f5cae4e")
     (html       "92c17db")

--- a/langs/tree-sitter-langs.el
+++ b/langs/tree-sitter-langs.el
@@ -81,6 +81,7 @@ See `tree-sitter-langs-repos'."
      (reverse '((agda-mode       . agda)
                 (sh-mode         . bash)
                 (c-mode          . c)
+                (csharp-mode     . c-sharp)
                 (c++-mode        . cpp)
                 (css-mode        . css)
                 (elm-mode        . elm)

--- a/langs/tree-sitter-langs.el
+++ b/langs/tree-sitter-langs.el
@@ -83,6 +83,7 @@ See `tree-sitter-langs-repos'."
                 (c-mode          . c)
                 (c++-mode        . cpp)
                 (css-mode        . css)
+                (elm-mode        . elm)
                 (go-mode         . go)
                 (haskell-mode    . haskell)
                 (html-mode       . html)


### PR DESCRIPTION
Hello!
As a first step to fix https://github.com/emacs-csharp/csharp-mode/issues/201 I think it is a good idea to add support for  `emacs-tree-sitter` to `csharp-mode`. I also added `elm-mode` since I'm also working on a major mode for that one. I hope I understood your documentation correctly. If not, please point me in the proper direction, and I will amend the changes provided here.

Have a nice day!