### PR TITLE
Add jump buttons to debug-tree-display

### DIFF
--- a/core/tsc.el
+++ b/core/tsc.el
@@ -157,7 +157,8 @@ This function must be called with narrowing disabled, e.g. within a
   (byte-to-position (tsc-node-end-byte node)))
 
 (defun tsc-node-position-range (node)
-  "Return NODE's (START-POSITION . END-POSITION)."
+  "Return NODE's (START-POSITION . END-POSITION).
+Must be called from NODE's associated source code buffer."
   (let ((range (tsc-node-byte-range node)))
     (cl-callf byte-to-position (car range))
     (cl-callf byte-to-position (cdr range))

--- a/lisp/tree-sitter-debug.el
+++ b/lisp/tree-sitter-debug.el
@@ -46,17 +46,16 @@ Only takes effect if `tree-sitter-debug-jump-buttons' is non-nil."
     (user-error "Source code buffer has been killed"))
   (unless button
     (user-error "This function must be called on a button"))
-  (let ((pos (button-get button 'points-to)))
-    (tree-sitter-debug--goto-node tree-sitter-debug--source-code-buffer
-                                  (car pos) (cdr pos))))
+  (tree-sitter-debug--goto-node tree-sitter-debug--source-code-buffer
+                                (button-get button 'points-to)))
 
-(defun tree-sitter-debug--goto-node (buffer start end)
-  "Switch to BUFFER, centering on the region defined by START and END."
+(defun tree-sitter-debug--goto-node (buffer node)
+  "Switch to BUFFER, centering on the region defined by NODE."
   (switch-to-buffer-other-window buffer)
-  (goto-char start)
-  (if end
-      (push-mark end t tree-sitter-debug-highlight-jump-region)
-    (deactivate-mark)))
+  (let ((range (tsc-node-position-range node)))
+    (goto-char (car range))
+    (push-mark (cdr range)
+               t tree-sitter-debug-highlight-jump-region)))
 
 (defun tree-sitter-debug--display-node (node depth)
   "Display NODE that appears at the given DEPTH in the syntax tree."
@@ -66,7 +65,7 @@ Only takes effect if `tree-sitter-debug-jump-buttons' is non-nil."
         (insert-button node-text
                        'action 'tree-sitter-debug--button-node-lookup
                        'follow-link t
-                       'points-to (tsc-node-position-range node))
+                       'points-to node)
       (insert node-text)))
   (tsc-mapc-children (lambda (c)
                        (when (tsc-node-named-p c)

--- a/lisp/tree-sitter-tests.el
+++ b/lisp/tree-sitter-tests.el
@@ -476,6 +476,18 @@ tree is held (since nodes internally reference the tree)."
     (garbage-collect)
     (message "     font-lock 10 %s" (benchmark-run 10 (font-lock-ensure)))))
 
+(ert-deftest debug::jump ()
+  "Test if the first button takes us to the beginning of the file.
+We know it should since it is the `source_file' node."
+  (tsc-test-lang-with-file 'rust "lisp/test-files/types.rs"
+    (let ((buf-name (buffer-name)))
+    (tree-sitter-debug-mode)
+    (goto-char (point-max))
+    (should (> (point) 0)) ; Test if worthless if the file is empty
+    (switch-to-buffer tree-sitter-debug--tree-buffer nil t)
+    (tree-sitter-debug--button-node-lookup (button-at 1))
+    (should (= (point) (point-min))))))
+
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; End:

--- a/lisp/tree-sitter-tests.el
+++ b/lisp/tree-sitter-tests.el
@@ -481,6 +481,7 @@ tree is held (since nodes internally reference the tree)."
 We know it should since it is the `source_file' node."
   (tsc-test-lang-with-file 'rust "lisp/test-files/types.rs"
     (let ((buf-name (buffer-name)))
+    (setq tree-sitter-debug-jump-buttons t)
     (tree-sitter-debug-mode)
     (goto-char (point-max))
     (should (> (point) 0)) ; Test if worthless if the file is empty


### PR DESCRIPTION
Short: jump from the tree-sitter-debug tree to the corresponding node in source text with emacs buttons. 

Long: turn the `tree-sitter-debug--display-tree` nodes into buttons. Each button has their `tsc-node-position-range` embedded in them as a text property. This allows us to define a function `tree-sitter-debug--button-node-lookup` which takes that information and jumps you to the relevant location in the source file buffer. 

This includes a new test. When I ran `make test`, I got 1 skip and 2 errors, before and after this change.
```
2 unexpected results:
   FAILED  hl::bench
   FAILED  hl::face-mapping

1 skipped results:
  SKIPPED  parsing::without-setting-language
```