### PR TITLE
Fix gzip error on Windows

### DIFF
--- a/langs/tree-sitter-langs-build.el
+++ b/langs/tree-sitter-langs-build.el
@@ -339,10 +339,11 @@ non-nil."
       ;; FIX: Handle HTTP errors properly.
       (url-copy-file (tree-sitter-langs--bundle-url version os)
                      bundle-file 'ok-if-already-exists)
-      (with-temp-buffer
-        (insert-file-contents bundle-file)
-        (tar-mode)
-        (tar-untar-buffer))
+      (unless
+          (ignore-errors
+            (with-temp-buffer
+              (insert-file-contents bundle-file) (tar-mode) (tar-untar-buffer)))
+        (shell-command (format "tar -xvzf %s%s" default-directory bundle-file)))
       ;; FIX: This should be a metadata file in the bundle itself.
       (with-temp-file tree-sitter-langs--bundle-version-file
         (let ((coding-system-for-write 'utf-8))

--- a/langs/tree-sitter-langs-build.el
+++ b/langs/tree-sitter-langs-build.el
@@ -339,9 +339,7 @@ non-nil."
       ;; FIX: Handle HTTP errors properly.
       (url-copy-file (tree-sitter-langs--bundle-url version os)
                      bundle-file 'ok-if-already-exists)
-      (shell-command (format "tar -xvzf %s"
-                             (shell-quote-argument
-                              (concat default-directory bundle-file))))
+      (tree-sitter-langs--call "tar" "-xvzf" bundle-file)
       ;; FIX: This should be a metadata file in the bundle itself.
       (with-temp-file tree-sitter-langs--bundle-version-file
         (let ((coding-system-for-write 'utf-8))

--- a/langs/tree-sitter-langs-build.el
+++ b/langs/tree-sitter-langs-build.el
@@ -343,7 +343,9 @@ non-nil."
           (ignore-errors
             (with-temp-buffer
               (insert-file-contents bundle-file) (tar-mode) (tar-untar-buffer)))
-        (shell-command (format "tar -xvzf %s%s" default-directory bundle-file)))
+        (shell-command (format "tar -xvzf %s"
+                               (shell-quote-argument
+                                (concat default-directory bundle-file)))))
       ;; FIX: This should be a metadata file in the bundle itself.
       (with-temp-file tree-sitter-langs--bundle-version-file
         (let ((coding-system-for-write 'utf-8))

--- a/langs/tree-sitter-langs-build.el
+++ b/langs/tree-sitter-langs-build.el
@@ -339,13 +339,9 @@ non-nil."
       ;; FIX: Handle HTTP errors properly.
       (url-copy-file (tree-sitter-langs--bundle-url version os)
                      bundle-file 'ok-if-already-exists)
-      (unless
-          (ignore-errors
-            (with-temp-buffer
-              (insert-file-contents bundle-file) (tar-mode) (tar-untar-buffer)))
-        (shell-command (format "tar -xvzf %s"
-                               (shell-quote-argument
-                                (concat default-directory bundle-file)))))
+      (shell-command (format "tar -xvzf %s"
+                             (shell-quote-argument
+                              (concat default-directory bundle-file))))
       ;; FIX: This should be a metadata file in the bundle itself.
       (with-temp-file tree-sitter-langs--bundle-version-file
         (let ((coding-system-for-write 'utf-8))


### PR DESCRIPTION
This resolved issue #85.  This works on Windows. 

Is there a reason that we must use `tar-mode` instead of just executing the shell command?

*P.S. I assumed most operating systems support `tar` command by default.*