### PR TITLE
Use static linking for C runtime on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.x86_64-pc-windows-msvc]
+# Avoid dynamic linking to vcruntime*.dll, which requires users to install VC++ redistributable
+# package. See https://github.com/ubolonton/emacs-tree-sitter/issues/86.
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
This fixes https://github.com/ubolonton/emacs-tree-sitter/issues/86.