### PR TITLE
Add Janet grammar to tree-sitter-langs

### DIFF
--- a/langs/tree-sitter-langs-build.el
+++ b/langs/tree-sitter-langs-build.el
@@ -89,6 +89,7 @@ If VERSION and OS are not specified, use the defaults of
     (fluent     "858fdd6")
     (go         "f5cae4e")
     (html       "92c17db")
+    (janet-simple "45418f7" nil "https://codeberg.org/sogaiu/tree-sitter-janet-simple")
     (java       "0b18a22")
     (javascript "3f8b62f")
     (jsdoc      "77e7785")


### PR DESCRIPTION
Please consider this PR for adding `tree-sitter-janet-simple` to `tree-sitter-langs-build.el`.

For reference, please see the following:
* https://github.com/ubolonton/emacs-tree-sitter/issues/95 (for background on why this is not `tree-sitter-janet`)
* https://github.com/ubolonton/emacs-tree-sitter/issues/101 (for motivation for this PR)