### PR TITLE
Apply query conversion rule

### DIFF
--- a/langs/queries/c/highlights.scm
+++ b/langs/queries/c/highlights.scm
@@ -115,7 +115,7 @@
 ;;; Misc.
 
 ((identifier) @constant
- (.match? @constant "^[A-Z_][A-Z_\\d]*$"))
+ (#match? @constant "^[A-Z_][A-Z_\\d]*$"))
 
 [(null) (true) (false)] @constant.builtin
 

--- a/langs/queries/cpp/highlights.scm
+++ b/langs/queries/cpp/highlights.scm
@@ -44,7 +44,7 @@
 ;; Types
 
 ((namespace_identifier) @type
- (.match? @type "^[A-Za-z]"))
+ (#match? @type "^[A-Za-z]"))
 
 (namespace_definition (identifier) @type)
 

--- a/langs/queries/css/highlights.scm
+++ b/langs/queries/css/highlights.scm
@@ -42,9 +42,9 @@
 (function_name) @function
 
 ((property_name) @variable
- (.match? @variable "^--"))
+ (#match? @variable "^--"))
 ((plain_value) @variable
- (.match? @variable "^--"))
+ (#match? @variable "^--"))
 
 "@media" @keyword
 "@import" @keyword

--- a/langs/queries/java/highlights.scm
+++ b/langs/queries/java/highlights.scm
@@ -26,7 +26,7 @@
 
 ((scoped_identifier
   scope: (identifier) @type)
- (.match? @type "^[A-Z]"))
+ (#match? @type "^[A-Z]"))
 
 (constructor_declaration
   name: (identifier) @type)
@@ -40,7 +40,7 @@
 ; Variables
 
 ((identifier) @constant
- (.match? @constant "^[A-Z_][A-Z_\\d]*$"))
+ (#match? @constant "^[A-Z_][A-Z_\\d]*$"))
 
 (this) @variable.builtin
 

--- a/langs/queries/javascript/highlights.scm
+++ b/langs/queries/javascript/highlights.scm
@@ -1,21 +1,21 @@
 ;; Special identifiers
 
 ((identifier) @constant
- (.match? @constant "^[A-Z_][A-Z_\\d]*$"))
+ (#match? @constant "^[A-Z_][A-Z_\\d]*$"))
 
 ((shorthand_property_identifier) @constant
- (.match? @constant "^[A-Z_][A-Z_\\d]*$"))
+ (#match? @constant "^[A-Z_][A-Z_\\d]*$"))
 
 ((identifier) @constructor
- (.match? @constructor "^[A-Z]"))
+ (#match? @constructor "^[A-Z]"))
 
 ((identifier) @variable.builtin
- (.match? @variable.builtin "^(arguments|module|console|window|document)$")
- (.is-not? local))
+ (#match? @variable.builtin "^(arguments|module|console|window|document)$")
+ (#is-not? local))
 
 ((identifier) @function.builtin
- (.eq? @function.builtin "require")
- (.is-not? local))
+ (#eq? @function.builtin "require")
+ (#is-not? local))
 
 ;; Function and method definitions
 

--- a/langs/queries/php/highlights.scm
+++ b/langs/queries/php/highlights.scm
@@ -42,13 +42,13 @@
 (relative_scope) @variable.builtin
 
 ((name) @constant
- (.match? @constant "^[A-Z_][A-Z_\\d]*$"))
+ (#match? @constant "^[A-Z_][A-Z_\\d]*$"))
 
 ((name) @constructor
- (.match? @constructor "^[A-Z]"))
+ (#match? @constructor "^[A-Z]"))
 
 ((name) @variable.builtin
- (.eq? @variable.builtin "this"))
+ (#eq? @variable.builtin "this"))
 
 (variable_name) @variable
 

--- a/langs/queries/python/highlights.scm
+++ b/langs/queries/python/highlights.scm
@@ -1,11 +1,11 @@
 ;; Built-ins.
 
 ((identifier) @constant.builtin
- (.match? @constant.builtin "^(__all__|__doc__|__name__|__package__|NotImplemented|Ellipsis)$"))
+ (#match? @constant.builtin "^(__all__|__doc__|__name__|__package__|NotImplemented|Ellipsis)$"))
 
 ;; XXX: Not really a keyword, but it's sort of a tradition.
 ((identifier) @keyword
- (.eq? @keyword "self"))
+ (#eq? @keyword "self"))
 
 ;; Function definitions.
 
@@ -21,7 +21,7 @@
                  (subscript (identifier) @type.builtin)])])
   (class_definition superclasses: (_ (identifier) @type.builtin))]
  ;; TODO: Include built-in exception types.
- (.match? @type.builtin "^(bool|bytearray|bytes|dict|float|int|list|object|set|str|tuple|unicode)$"))
+ (#match? @type.builtin "^(bool|bytearray|bytes|dict|float|int|list|object|set|str|tuple|unicode)$"))
 (type [(subscript
         value: (identifier) @type
         subscript: (identifier) @type.argument)
@@ -72,16 +72,16 @@
 ;; Identifier naming conventions.
 
 ((identifier) @constant
- (.match? @constant "^[A-Z_][A-Z_\\d]*$"))
+ (#match? @constant "^[A-Z_][A-Z_\\d]*$"))
 
 ((identifier) @constructor
- (.match? @constructor "^[A-Z]"))
+ (#match? @constructor "^[A-Z]"))
 
 ;; Function calls.
 
 ((call
   function: (identifier) @function.builtin)
- (.match?
+ (#match?
    @function.builtin
    "^(abs|all|any|ascii|bin|bool|breakpoint|bytearray|bytes|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|exec|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|print|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__)$"))
 (call function: [(attribute attribute: (identifier) @method.call)
@@ -170,7 +170,7 @@
 
 (comment) @comment
 ((string) @doc
- (.match? @doc "^\"\"\""))
+ (#match? @doc "^\"\"\""))
 (string) @string
 
 (decorator) @function.special

--- a/langs/queries/ruby/highlights.scm
+++ b/langs/queries/ruby/highlights.scm
@@ -29,12 +29,12 @@
 "yield" @keyword
 
 ((identifier) @keyword
- (.match? @keyword "^(private|protected|public)$"))
+ (#match? @keyword "^(private|protected|public)$"))
 
 ; Function calls
 
 ((identifier) @function.method.builtin
- (.eq? @function.method.builtin "require"))
+ (#eq? @function.method.builtin "require"))
 
 "defined?" @function.method.builtin
 
@@ -62,10 +62,10 @@
 (instance_variable) @property
 
 ((identifier) @constant.builtin
- (.match? @constant.builtin "^__(FILE|LINE|ENCODING)__$"))
+ (#match? @constant.builtin "^__(FILE|LINE|ENCODING)__$"))
 
 ((constant) @constant
- (.match? @constant "^[A-Z_][A-Z_\\d]*$"))
+ (#match? @constant "^[A-Z_][A-Z_\\d]*$"))
 
 (constant) @constructor
 
@@ -83,7 +83,7 @@
 (keyword_parameter (identifier) @variable.parameter)
 
 ((identifier) @function.method
- (.is-not? local))
+ (#is-not? local))
 (identifier) @variable
 
 ; Literals

--- a/langs/queries/rust/highlights.scm
+++ b/langs/queries/rust/highlights.scm
@@ -1,24 +1,24 @@
 ;;; Identifier conventions
 
 ((identifier) @keyword
- (.eq? @keyword "Self"))
+ (#eq? @keyword "Self"))
 ((type_identifier) @keyword
- (.eq? @keyword "Self"))
+ (#eq? @keyword "Self"))
 
 ;; Assume all-cap names are constants.
 ((identifier) @constant
- (.match? @constant "^[A-Z_][A-Z_\\d]*$"))
+ (#match? @constant "^[A-Z_][A-Z_\\d]*$"))
 
 ;; Assume that uppercase names in paths are types.
 ((scoped_identifier
   path: [(identifier) @type
          (scoped_identifier
           name: (identifier) @type)])
- (.match? @type "^[A-Z]"))
+ (#match? @type "^[A-Z]"))
 
 ;; Assume other uppercase names are enum constructors
 ((identifier) @constructor
- (.match? @constructor "^[A-Z]"))
+ (#match? @constructor "^[A-Z]"))
 
 ;;; Function calls.
 
@@ -79,7 +79,7 @@
 ;;; Comments and docstrings.
 
 ((line_comment) @doc
- (.match? @doc "^///"))
+ (#match? @doc "^///"))
 [(line_comment)
  (block_comment)] @comment
 
@@ -113,7 +113,7 @@
 ;;; Lifetime.
 
 ((lifetime (identifier) @type.builtin)
- (.eq? @type.builtin "static"))
+ (#eq? @type.builtin "static"))
 (lifetime (identifier) @label)
 
 ;;; Keywords.

--- a/langs/tree-sitter-langs.el
+++ b/langs/tree-sitter-langs.el
@@ -119,8 +119,8 @@ See `tree-sitter-langs-repos'."
   "Convert QUERY so it matches the core `emacs-tree-sitter' engine."
   (when (stringp query)
     (setq query (s-replace "#match?" ".match?" query)
-          query (s-replace "#eq?" ".eq?")
-          query (s-replace "#is-not?" ".is-not?")))
+          query (s-replace "#eq?" ".eq?" query)
+          query (s-replace "#is-not?" ".is-not?" query)))
   query)
 
 (defun tree-sitter-langs--hl-default-patterns (lang-symbol)

--- a/langs/tree-sitter-langs.el
+++ b/langs/tree-sitter-langs.el
@@ -6,7 +6,7 @@
 ;; Keywords: languages tools parsers tree-sitter
 ;; Homepage: https://github.com/ubolonton/emacs-tree-sitter
 ;; Version: 0.9.1
-;; Package-Requires: ((emacs "25.1") (tree-sitter "0.12.2"))
+;; Package-Requires: ((emacs "25.1") (tree-sitter "0.12.2") (s "1.9.0"))
 ;; License: MIT
 
 ;;; Commentary:
@@ -33,6 +33,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 's)
 
 (require 'tree-sitter)
 (require 'tree-sitter-load)
@@ -114,6 +115,14 @@ See `tree-sitter-langs-repos'."
                    (symbol-name lang-symbol)))
           "highlights.scm"))
 
+(defun tree-sitter-langs--query-conversion (query)
+  "Convert QUERY so it matches the core `emacs-tree-sitter' engine."
+  (when (stringp query)
+    (setq query (s-replace "#match?" ".match?" query)
+          query (s-replace "#eq?" ".eq?")
+          query (s-replace "#is-not?" ".is-not?")))
+  query)
+
 (defun tree-sitter-langs--hl-default-patterns (lang-symbol)
   "Return the bundled default syntax highlighting patterns for LANG-SYMBOL.
 Return nil if there are no bundled patterns."
@@ -128,7 +137,7 @@ Return nil if there are no bundled patterns."
           (insert-file-contents (tree-sitter-langs--hl-query-path sym))
           (goto-char (point-max))
           (insert "\n"))
-        (buffer-string))
+        (tree-sitter-langs--query-conversion (buffer-string)))
     (file-missing nil)))
 
 (defun tree-sitter-langs--set-hl-default-patterns (&rest _args)


### PR DESCRIPTION
Instead of editing the `highlights.scm` files directly, we convert it from code.