### PR TITLE
Do not quote generated lambda expressions

### DIFF
--- a/lisp/tree-sitter.el
+++ b/lisp/tree-sitter.el
@@ -264,7 +264,7 @@ Both SETUP-FUNCTION and TEARDOWN-FUNCTION should be idempotent."
            ;; Disable MODE when `tree-sitter-mode' is disabled. Quoting is
            ;; important, because we don't want a variable-capturing closure.
            (add-hook 'tree-sitter--before-off-hook
-                     '(lambda () (,mode -1))
+                     (with-no-warnings '(lambda () (,mode -1)))
                      nil :local))
        ,teardown)))
 


### PR DESCRIPTION
``` emacs-lisp
Compiling /home/jonas/.emacs.d/lib/tree-sitter/lisp/tree-sitter-debug.el...

In tree-sitter-debug-mode:
lib/tree-sitter/lisp/tree-sitter-debug.el:109:7: Warning: (lambda nil \.\.\.)
    quoted with ' rather than with #'
Compiling /home/jonas/.emacs.d/lib/tree-sitter/lisp/tree-sitter-extras.el...
Compiling /home/jonas/.emacs.d/lib/tree-sitter/lisp/tree-sitter-hl.el...

In tree-sitter-hl-mode:
lib/tree-sitter/lisp/tree-sitter-hl.el:643:7: Warning: (lambda nil \.\.\.)
    quoted with ' rather than with #'
```

(No quoting is needed.  You could wrap the lambda in `function`, but that doesn't really do anything, see http://www.gnu.org/software/emacs/manual/html_node/elisp/Anonymous-Functions.html)